### PR TITLE
Read OIDs in Big-Endian Order

### DIFF
--- a/ui/keypair.c
+++ b/ui/keypair.c
@@ -17,7 +17,8 @@
 int main(int argc, char **argv)
 {
     xmss_params params;
-    uint32_t oid;
+    uint32_t oid = 0;
+    int parse_oid_result = 0;
 
     if (argc != 2) {
         fprintf(stderr, "Expected parameter string (e.g. 'XMSS-SHA2_10_256')"
@@ -27,7 +28,11 @@ int main(int argc, char **argv)
     }
 
     XMSS_STR_TO_OID(&oid, argv[1]);
-    XMSS_PARSE_OID(&params, oid);
+    parse_oid_result = XMSS_PARSE_OID(&params, oid);
+    if (parse_oid_result != 0) {
+        fprintf(stderr, "Error parsing oid.\n");
+        return parse_oid_result;
+    }
 
     unsigned char pk[XMSS_OID_LEN + params.pk_bytes];
     unsigned char sk[XMSS_OID_LEN + params.sk_bytes];
@@ -38,4 +43,6 @@ int main(int argc, char **argv)
     fwrite(sk, 1, XMSS_OID_LEN + params.sk_bytes, stdout);
 
     fclose(stdout);
+
+    return 0;
 }

--- a/ui/open.c
+++ b/ui/open.c
@@ -3,6 +3,7 @@
 
 #include "../params.h"
 #include "../xmss.h"
+#include "../utils.h"
 
 #ifdef XMSSMT
     #define XMSS_PARSE_OID xmssmt_parse_oid
@@ -17,7 +18,9 @@ int main(int argc, char **argv) {
     FILE *sm_file;
 
     xmss_params params;
-    uint32_t oid;
+    uint32_t oid = 0;
+    uint8_t buffer[XMSS_OID_LEN];
+    int parse_oid_result;
 
     unsigned long long smlen;
     int ret;
@@ -39,6 +42,7 @@ int main(int argc, char **argv) {
     sm_file = fopen(argv[2], "rb");
     if (sm_file == NULL) {
         fprintf(stderr, "Could not open signature + message file.\n");
+        fclose(keypair_file);
         return -1;
     }
 
@@ -46,8 +50,15 @@ int main(int argc, char **argv) {
     fseek(sm_file, 0, SEEK_END);
     smlen = ftell(sm_file);
 
-    fread(&oid, 1, XMSS_OID_LEN, keypair_file);
-    XMSS_PARSE_OID(&params, oid);
+    fread(&buffer, 1, XMSS_OID_LEN, keypair_file);
+    oid = (uint32_t)bytes_to_ull(buffer, XMSS_OID_LEN);
+    parse_oid_result = XMSS_PARSE_OID(&params, oid);
+    if (parse_oid_result != 0) {
+        fprintf(stderr, "Error parsing oid.\n");
+        fclose(keypair_file);
+        fclose(sm_file);
+        return parse_oid_result;
+    }
 
     unsigned char pk[XMSS_OID_LEN + params.pk_bytes];
     unsigned char *sm = malloc(smlen);


### PR DESCRIPTION
There was a bug in the UI tools that can cause `ui/xmss_sign` to crash. The cause is that it was getting invalid data when reading the oid from the keypair file. The reason the data was invalid is that it was not being interpreted as a big-endian uint32 (at least on a little-endian test machine). 

This change rearranges the bytes so that we get back the original oid value.